### PR TITLE
Update for 2021

### DIFF
--- a/ShifterTools/DrawHitEfficiencyVsLumi.py
+++ b/ShifterTools/DrawHitEfficiencyVsLumi.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import math
 from ROOT import TCanvas, TGraph, TGraphAsymmErrors, TFile, TEfficiency
+import ctypes
 
 import ROOT
 ROOT.gROOT.SetBatch(True)
@@ -43,14 +44,14 @@ def add_points(graph, directory, layer, usePU):
         htotal = fdir.Get("all")
 
         if htotal == None:
-          print '  Missing histogram in file '+frun.GetName()
+          print('  Missing histogram in file '+frun.GetName())
           continue
 
         # lumi
         if usePU==0 : hlumi = fdir.Get("instLumi")
         else : hlumi = fdir.Get("PU")
         if hlumi == None:
-          print '  Missing lumi/pu histogram in file '+frun.GetName()
+          print('  Missing lumi/pu histogram in file '+frun.GetName())
           continue
         lumi = hlumi.GetMean()
         lumi_err = hlumi.GetRMS()
@@ -68,7 +69,7 @@ def add_points(graph, directory, layer, usePU):
           eff_vs_lumi.SetPoint(ipt, lumi, eff)
           low = TEfficiency.Bayesian(total, found, .683, 1, 1, False)
           up = TEfficiency.Bayesian(total, found, .683, 1, 1, True);
-          if eff-low > 0.01: print 'large error bar for run', run, 'layer', layer, 'eff:', '{:.4f}'.format(eff), 'err:', '{:.4f}'.format(eff-low)
+          if eff-low > 0.01: print('large error bar for run', run, 'layer', layer, 'eff:', '{:.4f}'.format(eff), 'err:', '{:.4f}'.format(eff-low))
           #if lumi_err > lumi/3.: print 'wide lumi range for run', run, 'layer', layer, 'eff:', '{:.4f}'.format(eff), 'lumi/pu:', '{:.4f}'.format(lumi), 'rms:', '{:.4f}'.format(lumi_err)
           eff_vs_lumi.SetPointError(ipt, lumi_err, lumi_err, eff-low, up-eff)
           ipt+=1
@@ -79,8 +80,8 @@ def add_points(graph, directory, layer, usePU):
 hiteffdir="/afs/cern.ch/cms/tracker/sistrvalidation/WWW/CalibrationValidation/HitEfficiency"
 
 if len(sys.argv)<2:
-  print "Syntax is:  DrawHitEfficiencyVsLumi.py  ERA [usePU] "
-  print "  example:  DrawHitEfficiencyVsLumi.py GR17 [1]"
+  print("Syntax is:  DrawHitEfficiencyVsLumi.py  ERA [usePU] ")
+  print("  example:  DrawHitEfficiencyVsLumi.py GR17 [1]")
   exit() 
 
 era=str(sys.argv[1])
@@ -100,7 +101,7 @@ c1 = TCanvas()
 
 for layer in range(1,35):
 
-  print 'producing trend plot for layer '+str(layer)
+  print('producing trend plot for layer '+str(layer))
 
   graphs.append( TGraphAsymmErrors() )
   eff_vs_lumi = graphs[-1]
@@ -117,8 +118,8 @@ for layer in range(1,35):
 
   eff_vs_lumi_lastpt = TGraphAsymmErrors()
   npt = eff_vs_lumi.GetN()
-  x, y = ROOT.Double(0), ROOT.Double(0)
-  eff_vs_lumi.GetPoint(npt-1, x, y)
+  x, y = ROOT.double(0), ROOT.double(0)
+  eff_vs_lumi.GetPoint(npt-1, ctypes.c_double(x), ctypes.c_double(y))
   eff_vs_lumi_lastpt.SetPoint(0, x, y)
   eff_vs_lumi_lastpt.SetMarkerStyle(24)
   eff_vs_lumi_lastpt.SetMarkerColor(2)

--- a/ShifterTools/DrawHitEfficiencyVsRun.py
+++ b/ShifterTools/DrawHitEfficiencyVsRun.py
@@ -49,7 +49,7 @@ def add_points(graph, directory, subdir, layer):
         htotal = fdir.Get("all")
 
         if htotal == None: 
-          print '  Missing histogram in file '+frun.GetName()
+          print('  Missing histogram in file '+frun.GetName())
           continue
 
         # efficiency for a given layer
@@ -139,8 +139,8 @@ def draw_subdet(graphs, subdet):
 hiteffdir="/afs/cern.ch/cms/tracker/sistrvalidation/WWW/CalibrationValidation/HitEfficiency"
 
 if len(sys.argv)<3:
-  print "Syntax is:  DrawHitEfficiencyVsRun.py  ERA  SUBDIRECTORY"
-  print "  example:  DrawHitEfficiencyVsRun.py GR17 standard"
+  print("Syntax is:  DrawHitEfficiencyVsRun.py  ERA  SUBDIRECTORY")
+  print("  example:  DrawHitEfficiencyVsRun.py GR17 standard")
   exit() 
 
 era=str(sys.argv[1])
@@ -157,7 +157,7 @@ graphs=[]
 
 for layer in range(1,35):
 
-  print 'producing trend plot for layer '+str(layer)
+  print('producing trend plot for layer '+str(layer))
 
   graphs.append( TGraphAsymmErrors() )
   eff_vs_run = graphs[-1]

--- a/ShifterTools/HitEffDriver.sh
+++ b/ShifterTools/HitEffDriver.sh
@@ -137,7 +137,7 @@ fi
 
 # Default values for options
 # Run period
-ERA="GR18"
+ERA="GR21"
 # nb of files to be processed for the run
 NFILES="4"
 

--- a/ShifterTools/TrendPlots.sh
+++ b/ShifterTools/TrendPlots.sh
@@ -79,22 +79,22 @@ mkdir -p $wwwdir/$ERA/TrendPlots
 
 echo "Using outputs from 'standard' directories"
 mkdir -p $wwwdir/$ERA/TrendPlots/standard
-python2.7 DrawHitEfficiencyVsRun.py $ERA standard
+python3 DrawHitEfficiencyVsRun.py $ERA standard
 StoreTrendPlotsOutput SiStripHitEffTrendPlot $ERA standard
 
 echo "Using outputs from 'withMasking' directories"
 mkdir -p $wwwdir/$ERA/TrendPlots/withMasking
-python2.7 DrawHitEfficiencyVsRun.py $ERA withMasking
+python3 DrawHitEfficiencyVsRun.py $ERA withMasking
 StoreTrendPlotsOutput SiStripHitEffTrendPlot $ERA withMasking
 
 echo "Using outputs from 'withMasking' directories for results vs inst. lumi."
 mkdir -p $wwwdir/$ERA/TrendPlots/vsLumi
-python2.7 DrawHitEfficiencyVsLumi.py $ERA
+python3 DrawHitEfficiencyVsLumi.py $ERA
 StoreTrendPlotsOutput SiStripHitEffTrendPlotVsLumi $ERA vsLumi
 
 echo "Using outputs from 'withMasking' directories for results vs pile-up"
 mkdir -p $wwwdir/$ERA/TrendPlots/vsPU
-python2.7 DrawHitEfficiencyVsLumi.py $ERA 1
+python3 DrawHitEfficiencyVsLumi.py $ERA 1
 StoreTrendPlotsOutput SiStripHitEffTrendPlotVsPU $ERA vsPU
 
 


### PR DESCRIPTION
Updates to run on `CMSSW_12_0_X` with python3. Suitable for pilot beam test collisions in 2021 using calibTrees [1] (under production).

Instructions for test
```bash
cmsrel CMSSW_12_0_3_patch1
cd CMSSW_12_0_3_patch1/src
cmsenv
git clone git@github.com:robervalwalsh/StripHitEfficiency.git
cd StripHitEfficiency/ShifterTools
git checkout updateFor2021
./HitEffDriver.sh 346299
```

[1] /store/group/dpg_tracker_strip/comm_tracker/Strip/Calibration/calibrationtree/GR21/